### PR TITLE
Adding perform_setup option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,11 @@ inputs:
   branch_name: 
     description: "Current Branch"
     required: true
+  perform_setup:
+    description: "Perform Setup"
+    required: false
+    type: boolean
+    default: true
   java_version:
     description: "Java Version"
     required: false 
@@ -15,15 +20,18 @@ runs:
   using: "composite" 
   steps:
     - name: Checkout Repository
+      if: ${{ inputs.perform_setup }}
       uses: actions/checkout@v4
 
     - name: Setup Java
+      if: ${{ inputs.perform_setup }}
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: ${{inputs.java_version}}
 
     - name: Cache Maven packages
+      if: ${{ inputs.perform_setup }}
       uses: actions/cache@v3
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
Add ability to turn on/off the setup tasks in shared action. Default is to keep the setup tasks.